### PR TITLE
Add Nix overlay and version caching for Mise

### DIFF
--- a/.chezmoiscripts/run_before_update-claude-version.sh.tmpl
+++ b/.chezmoiscripts/run_before_update-claude-version.sh.tmpl
@@ -13,6 +13,9 @@
 {{- $cachedZedVersion := index . "zedVersion" | default "" -}}
 {{- $cachedZedHash := index . "zedHash" | default "" -}}
 
+{{- $cachedMiseVersion := index . "miseVersion" | default "" -}}
+{{- $cachedMiseHash := index . "miseHash" | default "" -}}
+
 #!/bin/sh
 claude_version="{{- includeTemplate "claude-version" . -}}"
 if [ "$claude_version" = "{{- $cachedClaudeVersion -}}" ] \
@@ -50,6 +53,15 @@ else
     zed_hash="{{- includeTemplate "zed-hash" . -}}"
 fi
 
+mise_version="{{- includeTemplate "mise-version" . -}}"
+if [ "$mise_version" = "{{- $cachedMiseVersion -}}" ] \
+    && [ -n "{{- $cachedMiseHash -}}" ]; then
+    echo "mise is up to date, using cached hash."
+    mise_hash="{{- $cachedMiseHash -}}"
+else
+    mise_hash="{{- includeTemplate "mise-hash" . -}}"
+fi
+
 if [ ! -d ~/.config/chezmoi ]; then
     mkdir -p ~/.config/chezmoi
 fi
@@ -67,6 +79,8 @@ geminiVersion = "$gemini_version"
 geminiHash = "$gemini_hash"
 zedVersion = "$zed_version"
 zedHash = "$zed_hash"
+miseVersion = "$mise_version"
+miseHash = "$mise_hash"
 EOF
 {{- end -}}
 

--- a/.chezmoitemplates/mise-hash
+++ b/.chezmoitemplates/mise-hash
@@ -1,0 +1,11 @@
+{{- $cachedVersion := index . "miseVersion" | default "" -}}
+{{- $cachedHash := index . "miseHash" | default "" -}}
+{{- $latestVersion := includeTemplate "mise-version" . | trim -}}
+{{- $hash := "" -}}
+{{- if and (eq $latestVersion $cachedVersion) (ne $cachedHash "") -}}
+  {{- $hash = $cachedHash -}}
+{{- else -}}
+  {{- $url := includeTemplate "mise-url" . -}}
+  {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
+{{- end -}}
+{{- $hash -}}

--- a/.chezmoitemplates/mise-url
+++ b/.chezmoitemplates/mise-url
@@ -1,0 +1,11 @@
+{{- $version := includeTemplate "mise-version" . -}}
+{{- $os := .chezmoi.os -}}
+{{- if eq $os "darwin" -}}
+  {{- $os = "macos" -}}
+{{- end -}}
+{{- $arch := .chezmoi.arch -}}
+{{- if eq $arch "amd64" -}}
+  {{- $arch = "x64" -}}
+{{- end -}}
+{{- printf "https://github.com/jdx/mise/releases/download/%s/mise-%s-%s-%s.tar.gz" $version $version $os $arch -}}
+

--- a/.chezmoitemplates/mise-version
+++ b/.chezmoitemplates/mise-version
@@ -1,0 +1,1 @@
+{{- output "sh" "-c" `curl -sI "https://github.com/jdx/mise/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}

--- a/private_dot_config/home-manager/exact_overlays/mise.nix.tmpl
+++ b/private_dot_config/home-manager/exact_overlays/mise.nix.tmpl
@@ -1,0 +1,15 @@
+final: prev: {
+  mise = prev.stdenv.mkDerivation {
+    pname = "mise";
+    version = "{{ includeTemplate `mise-version` . }}";
+    src = prev.fetchurl {
+      url = "{{ includeTemplate `mise-url` . }}";
+      hash = "{{ includeTemplate `mise-hash` . }}";
+    };
+    sourceRoot = ".";
+    nativeBuildInputs = [ prev.makeWrapper ];
+    installPhase = ''
+      install -Dm755 mise/bin/mise $out/bin/mise
+    '';
+  };
+}

--- a/private_dot_config/home-manager/flake.nix.tmpl
+++ b/private_dot_config/home-manager/flake.nix.tmpl
@@ -36,6 +36,7 @@
           (import ./overlays/github-copilot-cli.nix)
           (import ./overlays/gemini-cli.nix)
           (import ./overlays/zed-editor.nix)
+          (import ./overlays/mise.nix)
         ];
       };
     in


### PR DESCRIPTION
This pull request adds support for managing the installation and versioning of the `mise` tool (a runtime manager) in the configuration system, similar to how other tools like `zed` are handled. The changes introduce new templates and scripts to fetch, cache, and verify the latest `mise` version and hash, and integrate `mise` as a Nix overlay for reproducible builds.

**Support for `mise` version management and Nix overlay integration:**

* Added new templates to fetch the latest `mise` version (`mise-version`), construct the download URL (`mise-url`), and compute/cache the hash (`mise-hash`) for the release tarball. 
* Added a new Nix overlay template (`mise.nix.tmpl`) to build and install `mise` from the fetched tarball, ensuring reproducible and up-to-date installations.
* Integrated the new `mise` overlay into the Home Manager flake configuration, so that it is included alongside other overlays.

Closes #5 