### PR TITLE
fix(home-manager): correct amd64 arch mapping to x86_64

### DIFF
--- a/private_dot_config/home-manager/flake.nix.tmpl
+++ b/private_dot_config/home-manager/flake.nix.tmpl
@@ -23,7 +23,7 @@
       arch = "{{ .chezmoi.arch }}";
       archMap = {
           "arm64" = "aarch64";
-          "amd64" = "amd64";
+          "amd64" = "x86_64";
         };
       archName = archMap.${arch} or arch;
       system = "${archName}-${os}";


### PR DESCRIPTION
Closes #3 