### PR TITLE
fix(tmux): render status bar clock via shell to honor TZ

### DIFF
--- a/private_dot_config/tmux/tmux.conf.tmpl
+++ b/private_dot_config/tmux/tmux.conf.tmpl
@@ -78,7 +78,7 @@ set-environment -g TZ '{{ env "TZ" | default "UTC" }}'
 
 # status bar ==================================================================
 set -g status-position bottom
-set -g status-right "#(TZ='{{ env "TZ" | default "UTC" }}' date '+ %Y-%m-%d  %H:%M:%S')"
+set -g status-right "#(TZ='{{ env "TZ" | default "UTC" }}' date '+ %%Y-%%m-%%d  %%H:%%M:%%S')"
 set -g status-interval 1
 if-shell -b '[ "$(uname)" = "Darwin" ]' {
     set -g status-left "#[fg=#aeaed2,bg=#000000]░▒▓#[fg=#000000,bg=##aeaed2]  #[fg=#aeaed2,bg=#000000]#[default] #S "

--- a/private_dot_config/tmux/tmux.conf.tmpl
+++ b/private_dot_config/tmux/tmux.conf.tmpl
@@ -78,7 +78,7 @@ set-environment -g TZ '{{ env "TZ" | default "UTC" }}'
 
 # status bar ==================================================================
 set -g status-position bottom
-set -g status-right " %Y-%m-%d  %H:%M:%S"
+set -g status-right "#(TZ='{{ env "TZ" | default "UTC" }}' date '+ %Y-%m-%d  %H:%M:%S')"
 set -g status-interval 1
 if-shell -b '[ "$(uname)" = "Darwin" ]' {
     set -g status-left "#[fg=#aeaed2,bg=#000000]░▒▓#[fg=#000000,bg=##aeaed2]  #[fg=#aeaed2,bg=#000000]#[default] #S "


### PR DESCRIPTION
## Summary

- Switch the tmux status bar clock from tmux's built-in `strftime` to a shell-rendered `date` invocation so the displayed time honors the timezone baked in by chezmoi.

## Why

tmux evaluates `%Y`, `%H`, etc. in `status-right` using the **server process's own** `tzset()` cache, captured when the server first started. `set-environment -g TZ "..."` (added in #8) updates the global tmux environment that is passed to *child* processes, but does not call `tzset()` on the server itself, so the clock keeps rendering in whatever timezone the server originally inherited (often `UTC`).

Running `date` inside `#(...)` spawns a fresh subprocess every refresh interval, and that subprocess reads `TZ` from its own environment — so the clock always renders in the configured timezone regardless of how/when the tmux server was started.

## Change

```diff
-set -g status-right "<calendar> %Y-%m-%d <clock> %H:%M:%S"
+set -g status-right "#(TZ='{{ env "TZ" | default "UTC" }}' date '+<calendar> %Y-%m-%d <clock> %H:%M:%S')"
```

(Nerd Font glyphs preserved; chezmoi expands `{{ env "TZ" | default "UTC" }}` at apply time.)

## Test plan

- [ ] `chezmoi apply` on macOS with `TZ=Asia/Tokyo`; verify the status bar clock shows JST.
- [ ] `chezmoi apply` on Linux with `TZ` unset; verify the rendered conf falls back to `UTC`.
- [ ] `chezmoi apply` on Windows (WSL) with `TZ=Asia/Tokyo`; verify JST is shown.
- [ ] Confirm the clock continues to refresh every second (`status-interval 1`).

Closes #10
