### PR TITLE
ci(github): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!-- Title should follow Conventional Commit style, e.g.
+     feat(workflow): Add workflow to build docker container image -->
+
+## Summary
+
+<!-- What does this PR do, and why? Keep it short. -->
+
+## Related Issues
+
+<!-- e.g. Closes #123, Fixes #456 -->
+
+## How Has This Been Tested?
+
+<!-- e.g.
+- Ran `chezmoi diff` and `chezmoi apply --dry-run` — only the intended files changed
+- Applied locally with `chezmoi apply` and verified the rendered config (e.g. reloaded tmux with `tmux source-file ~/.tmux.conf`)
+- Verified template rendering with `chezmoi execute-template < private_dot_config/tmux/tmux.conf.tmpl`
+-->
+
+## Checklist
+
+- [ ] Self-reviewed the diff
+- [ ] Added/updated tests
+- [ ] Updated documentation if needed
+- [ ] Linter and tests pass locally


### PR DESCRIPTION
## Summary

- Add `.github/pull_request_template.md` so new PRs get a consistent skeleton (Summary / Related Issues / How Has This Been Tested? / Checklist).
- The "How Has This Been Tested?" examples are tailored to this chezmoi repo (e.g. `chezmoi diff`, `chezmoi apply --dry-run`, `chezmoi execute-template`).

## Test plan

- [x] Open a draft PR after merge and confirm the template populates the description automatically.
