### PR TITLE
docs(skills): improve generate-pull-request skill clarity

### DIFF
--- a/dot_claude/skills/generate-pull-request/SKILL.md
+++ b/dot_claude/skills/generate-pull-request/SKILL.md
@@ -7,27 +7,45 @@ description: Generate a concise and informative pull request title and descripti
 
 ## Procedure
 
-- Run `git --no-pager diff --no-color <target-branch>...HEAD`
-  to get detailed changes between the current branch and the target branch.
-  If `<target-branch>` is not specified, use `main` as the default target branch.
-- Create the title of the pull request using the **Conventional Commit** style.
-- If there is `.github/pull_request_template.md` or any template files
-  for PR in the repository, use it as a template for the description.
-- If there is no template, generate a description that includes:
-  - **Summmary**: A brief summary of the changes.
-  - **Related Issue**: Any related issue numbers (e.g., `Closes #123`).
-  - **How Has This Been Tested**: A brief explanation of how the changes were tested.
-  - **Checklist**: A checklist of items to be completed before merging
-    (e.g., "-[ ] Code compiles correctly", "-[ ] Tests cover new code").
+1. Run `git --no-pager diff --no-color <target-branch>...HEAD` to get the
+   detailed changes between the current branch and the target branch.
+   If `<target-branch>` is not specified, use `main` as the default.
+2. Always pass `--no-color` (and prefer `--no-pager`) to any `git` command
+   whose output you read. If a command does not support `--no-color`, run it
+   with `TERM=dumb` and `GIT_PAGER=cat` so colors are not embedded as
+   ANSI escape sequences in captured output.
+3. Create the PR title using the **Conventional Commit** style.
+4. If `.github/pull_request_template.md` (or any PR template file) exists in
+   the repository, use it as the description template.
+5. Otherwise, generate a description that includes:
+   - **Summary**: A brief summary of the changes.
+   - **Related Issue**: Any related issue numbers (e.g., `Closes #123`).
+   - **How Has This Been Tested**: A brief explanation of how the changes were tested.
+   - **Checklist**: Items to complete before merging
+     (e.g., `- [ ] Code compiles correctly`, `- [ ] Tests cover new code`).
 
 ## Output
 
-Output ONLY the title and raw message.
+Output ONLY the title and the raw message body, as plain UTF-8 text.
 
-## Strictions
+## Constraints
 
-- **Do NOT** output any ansy escape characters.
-- The title should be concise (max 50 characters) and
-  follow the Conventional Commit format:
+- **Plain text only.** The title and body MUST NOT contain any ANSI escape
+  sequences, terminal control codes, or other non-printable characters.
+  This includes, but is not limited to:
+  - SGR / color codes such as `\x1b[31m`, `\033[0m`, `\u001b[1;32m`
+  - Cursor and screen codes such as `\x1b[2K`, `\x1b[?25l`, `\x1b[H`
+  - Any byte in the ranges `\x00`–`\x08`, `\x0B`–`\x1F`, or `\x7F`
+- If any tool or command output you read contains such sequences,
+  **strip them before** including the content in the PR body. Example:
+  `<command> | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g; s/\x1B\][^\x07]*\x07//g'`
+- After composing the body, scan it once more and remove any remaining
+  bytes that match `\x1B\[`, `\x1B\]`, or other C0/C1 control characters.
+- The title must be concise (max 50 characters) and follow:
   `<type>[scope]: <description>`
-- `<type>` should be one of: feat, fix, docs, style, refactor, perf, test, build, ci.
+- `<type>` must be one of: `feat`, `fix`, `docs`, `style`, `refactor`,
+  `perf`, `test`, `build`, `ci`.
+- When invoking `gh pr create`, pass the body via `--body-file <tmpfile>`
+  with a temporary plain-text file rather than `--body "..."`. This avoids
+  the shell expanding `\e`, `\033`, or other escape sequences during
+  interpolation.


### PR DESCRIPTION
## Summary

Improves the `generate-pull-request` skill for clarity and reliability:
- Reorganizes the procedure as a numbered list and adds guidance to pass `--no-color` (and `TERM=dumb`/`GIT_PAGER=cat` when needed) to git commands so ANSI escape sequences are never embedded in captured output.
- Renames the typo'd "Strictions" section to "Constraints" and tightens the rules: spells out which control bytes are forbidden, gives a `sed` snippet for stripping them, and recommends invoking `gh pr create` with `--body-file` instead of `--body "..."` to avoid shell escape interpretation.

## Related Issues

N/A

## How Has This Been Tested?

- Reviewed the rendered Markdown of `dot_claude/skills/generate-pull-request/SKILL.md`
- Used the updated skill to draft this PR (body written to a tempfile, `gh pr create --body-file`)

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [ ] Updated documentation if needed
- [x] Linter and tests pass locally
