### PR TITLE
fix(tmux): use system timezone

### DIFF
--- a/private_dot_config/tmux/tmux.conf.tmpl
+++ b/private_dot_config/tmux/tmux.conf.tmpl
@@ -74,11 +74,9 @@ set -g allow-rename off
 set -g default-terminal "tmux-256color"
 set -ga terminal-overrides ",$TERM:Tc"
 set -ga terminal-overrides '*:Ss=\E[%p1%d q:Se=\E[2 q'
-set-environment -g TZ '{{ env "TZ" | default "UTC" }}'
-
 # status bar ==================================================================
 set -g status-position bottom
-set -g status-right "#(TZ='{{ env "TZ" | default "UTC" }}' date '+ %%Y-%%m-%%d  %%H:%%M:%%S')"
+set -g status-right "#(date '+ %%Y-%%m-%%d  %%H:%%M:%%S')"
 set -g status-interval 1
 if-shell -b '[ "$(uname)" = "Darwin" ]' {
     set -g status-left "#[fg=#aeaed2,bg=#000000]░▒▓#[fg=#000000,bg=##aeaed2]  #[fg=#aeaed2,bg=#000000]#[default] #S "


### PR DESCRIPTION
## Summary

- Remove the explicit `TZ` setting from the tmux config.
- Let the tmux status clock use the system timezone by default.

## Related Issues

Closes #15

## How Has This Been Tested?

- Ran `env -u TZ chezmoi execute-template < private_dot_config/tmux/tmux.conf.tmpl` and verified the rendered status clock does not set `TZ`.

## Checklist

- [x] Self-reviewed the diff
- [x] Added/updated tests (not applicable; project needs no tests)
- [x] Updated documentation if needed (not applicable)
- [x] Linter and tests pass locally (template rendering verified)