### PR TITLE
feat(nvim): style WinSeparator with theme-aware colors

### DIFF
--- a/private_dot_config/nvim/init.lua
+++ b/private_dot_config/nvim/init.lua
@@ -74,7 +74,6 @@ vim.opt.updatetime = 500
 vim.opt.ttimeoutlen = 10
 vim.opt.timeoutlen = 500
 vim.opt.foldlevel = 99
-vim.api.nvim_set_hl(0, "WinSeparator", { fg = "fg", bg = "bg" })
 -- filetype
 vim.filetype.add({
   filename = {

--- a/private_dot_config/nvim/init.lua
+++ b/private_dot_config/nvim/init.lua
@@ -74,7 +74,7 @@ vim.opt.updatetime = 500
 vim.opt.ttimeoutlen = 10
 vim.opt.timeoutlen = 500
 vim.opt.foldlevel = 99
-
+vim.api.nvim_set_hl(0, "WinSeparator", { fg = "fg", bg = "bg" })
 -- filetype
 vim.filetype.add({
   filename = {
@@ -115,3 +115,11 @@ require("config.lazy")
 require("core.autocmds")
 require("core.commands")
 require("core.keymaps")
+
+vim.api.nvim_create_autocmd("ColorScheme", {
+  callback = function()
+    local src = vim.api.nvim_get_hl(0, { name = "Title" })
+    vim.api.nvim_set_hl(0, "WinSeparator", { fg = src.fg, bg = "NONE" })
+  end,
+})
+vim.api.nvim_exec_autocmds("ColorScheme", {})


### PR DESCRIPTION
<!-- Title should follow Conventional Commit style, e.g.
     feat(workflow): Add workflow to build docker container image -->

## Summary

- Add a `ColorScheme` autocmd in `init.lua` that overrides the `WinSeparator` highlight to use the current colorscheme's `Title` foreground (with a transparent background) so window separators stay visible and theme-aware across colorscheme changes.
- Fire `ColorScheme` once at startup so the override applies on the initial scheme load.

## Related Issues

N/A

## How Has This Been Tested?

- Ran `chezmoi diff` and confirmed only `private_dot_config/nvim/init.lua` changes.
- Applied locally with `chezmoi apply` and opened Neovim with split windows; verified the separator color matches the `Title` highlight and updates after `:colorscheme <name>`.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests (not applicable)
- [ ] Updated documentation if needed (not applicable)
- [x] Linter and tests pass locally
