### PR TITLE
feat(chezmoitemplates): guard templates against Windows OS

### DIFF
--- a/.chezmoitemplates/claude-hash
+++ b/.chezmoitemplates/claude-hash
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "claudeVersion" | default "" -}}
 {{- $cachedHash := index . "claudeHash" | default "" -}}
 {{- $latestVersion := includeTemplate "claude-version" . | trim -}}
@@ -9,3 +10,4 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}

--- a/.chezmoitemplates/claude-url
+++ b/.chezmoitemplates/claude-url
@@ -1,2 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "claude-version" . | trim -}}
 {{- printf "https://downloads.claude.ai/claude-code-releases/%s/%s-%s/claude" $version .chezmoi.os .chezmoi.arch -}}
+{{- end -}}

--- a/.chezmoitemplates/claude-version
+++ b/.chezmoitemplates/claude-version
@@ -1,1 +1,3 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "curl" "-fsSL" "https://downloads.claude.ai/claude-code-releases/latest" -}}
+{{- end -}}

--- a/.chezmoitemplates/copilot-hash
+++ b/.chezmoitemplates/copilot-hash
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "copilotVersion" | default "" -}}
 {{- $cachedHash := index . "copilotHash" | default "" -}}
 {{- $latestVersion := includeTemplate "copilot-version" . | trim -}}
@@ -9,3 +10,4 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}

--- a/.chezmoitemplates/copilot-url
+++ b/.chezmoitemplates/copilot-url
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "copilot-version" . -}}
 {{- $os := .chezmoi.os -}}
 {{- $arch := .chezmoi.arch -}}
@@ -5,3 +6,4 @@
   {{- $arch = "x64" -}}
 {{- end -}}
 {{- printf "https://github.com/github/copilot-cli/releases/download/%s/copilot-%s-%s.tar.gz" $version $os $arch -}}
+{{- end -}}

--- a/.chezmoitemplates/copilot-version
+++ b/.chezmoitemplates/copilot-version
@@ -1,1 +1,3 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" `curl -sI "https://github.com/github/copilot-cli/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}
+{{- end -}}

--- a/.chezmoitemplates/gemini-hash
+++ b/.chezmoitemplates/gemini-hash
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "geminiVersion" | default "" -}}
 {{- $cachedHash := index . "geminiHash" | default "" -}}
 {{- $latestVersion := includeTemplate "gemini-version" . | trim -}}
@@ -9,3 +10,4 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}

--- a/.chezmoitemplates/gemini-url
+++ b/.chezmoitemplates/gemini-url
@@ -1,2 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "gemini-version" . -}}
 {{- printf "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-%s.tgz" $version -}}
+{{- end -}}

--- a/.chezmoitemplates/gemini-version
+++ b/.chezmoitemplates/gemini-version
@@ -1,1 +1,3 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" "curl -s https://registry.npmjs.org/@google/gemini-cli/latest | grep -o '\"version\":\"[^\"]*\"' | cut -d'\"' -f4" | trim -}}
+{{- end -}}

--- a/.chezmoitemplates/mise-hash
+++ b/.chezmoitemplates/mise-hash
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "miseVersion" | default "" -}}
 {{- $cachedHash := index . "miseHash" | default "" -}}
 {{- $latestVersion := includeTemplate "mise-version" . | trim -}}
@@ -9,3 +10,4 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}

--- a/.chezmoitemplates/mise-url
+++ b/.chezmoitemplates/mise-url
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "mise-version" . -}}
 {{- $os := .chezmoi.os -}}
 {{- if eq $os "darwin" -}}
@@ -8,4 +9,5 @@
   {{- $arch = "x64" -}}
 {{- end -}}
 {{- printf "https://github.com/jdx/mise/releases/download/%s/mise-%s-%s-%s.tar.gz" $version $version $os $arch -}}
+{{- end -}}
 

--- a/.chezmoitemplates/mise-version
+++ b/.chezmoitemplates/mise-version
@@ -1,1 +1,3 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" `curl -sI "https://github.com/jdx/mise/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}
+{{- end -}}

--- a/.chezmoitemplates/yegappan-lsp-hash
+++ b/.chezmoitemplates/yegappan-lsp-hash
@@ -1,3 +1,5 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $url := "https://github.com/yegappan/lsp/archive/refs/heads/main.tar.gz" -}}
 {{- $hash := output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url --unpack '%s' 2>/dev/null)" $url) | trim -}}
 {{- $hash -}}
+{{- end -}}

--- a/.chezmoitemplates/zed-hash
+++ b/.chezmoitemplates/zed-hash
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "zedVersion" | default "" -}}
 {{- $cachedHash := index . "zedHash" | default "" -}}
 {{- $latestVersion := includeTemplate "zed-version" . | trim -}}
@@ -9,3 +10,4 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}

--- a/.chezmoitemplates/zed-url
+++ b/.chezmoitemplates/zed-url
@@ -1,3 +1,4 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "zed-version" . -}}
 {{- $os := .chezmoi.os -}}
 {{- $arch := .chezmoi.arch -}}
@@ -10,4 +11,5 @@
     {{- printf "https://github.com/zed-industries/zed/releases/download/%s/Zed-%s.dmg" $version $arch -}}
 {{- else if eq $os "linux" -}}
     {{- printf "https://github.com/zed-industries/zed/releases/download/%s/zed-linux-%s.tar.gz" $version $arch -}}
+{{- end -}}
 {{- end -}}

--- a/.chezmoitemplates/zed-version
+++ b/.chezmoitemplates/zed-version
@@ -1,1 +1,3 @@
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" `curl -sI "https://github.com/zed-industries/zed/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}
+{{- end -}}


### PR DESCRIPTION
## Summary

Wraps each reusable template in `.chezmoitemplates/` with the existing
`{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}} ... {{- end -}}`
OS guard so they render to an empty string on Windows.

Why: every chunk under `.chezmoitemplates/` ultimately invokes Unix-only
commands (`output "curl" ...`, `output "sh" "-c" ...` with `nix-prefetch-url`),
so rendering on Windows fails. The same guard pattern is already used in
`.chezmoiscripts/run_before_update-claude-version.sh.tmpl:1` — this change
extends it to every reusable chunk for consistency and defense-in-depth.

Files touched (all under `.chezmoitemplates/`):

- Version fetchers: `claude-version`, `copilot-version`, `gemini-version`, `zed-version`, `mise-version`
- Hash fetchers: `claude-hash`, `copilot-hash`, `gemini-hash`, `zed-hash`, `mise-hash`, `yegappan-lsp-hash`
- URL builders: `claude-url`, `copilot-url`, `gemini-url`, `zed-url`, `mise-url`

Each file gets +2 lines (guard open + `{{- end -}}`), no other changes.

## Related Issues

<!-- none -->

## How Has This Been Tested?

- Reviewed `git diff --stat`: 16 files changed, 32 insertions, 0 deletions — matches the intended 2-line wrap per file.
- Visually verified the wrapped output of a representative sample (`claude-version`, `claude-hash`, `zed-url`, `mise-url`) renders as expected.
- End-to-end `chezmoi execute-template` was not run in the authoring environment (chezmoi not installed there). Please run `chezmoi diff` locally to confirm no unintended changes on linux/darwin, and optionally simulate Windows to confirm empty output.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests (n/a — chezmoi templates)
- [ ] Updated documentation if needed (n/a)
- [ ] Linter and tests pass locally (chezmoi not available in authoring env)


---
_Generated by [Claude Code](https://claude.ai/code/session_015LHDhVhqXcKCuDTXmj8tWZ)_