### PR TITLE
fix(chezmoiscripts): skip update script on windows

### DIFF
--- a/.chezmoiscripts/run_after_update.sh.tmpl
+++ b/.chezmoiscripts/run_after_update.sh.tmpl
@@ -1,6 +1,8 @@
+{{- if ne .chezmoi.os "windows" -}}
 #!/bin/sh
 if command -v bat > /dev/null 2>&1; then
     bat ~/.config/chezmoi/chezmoi.toml
 else
     cat ~/.config/chezmoi/chezmoi.toml
 fi
+{{- end -}}


### PR DESCRIPTION
## Summary

Wrap the body of `.chezmoiscripts/run_after_update.sh.tmpl` in a `{{ if ne .chezmoi.os "windows" }}` guard so the template renders to empty content on Windows. This prevents `chezmoi apply` from failing on Windows, where `/bin/sh`, `bat`, and `cat` are not available, while preserving the existing post-update behavior on Linux and macOS.

## Related Issues

Closes #19

## How Has This Been Tested?

- Ran `chezmoi execute-template < .chezmoiscripts/run_after_update.sh.tmpl` on macOS and confirmed the rendered script is identical to the previous version.
- Simulated a Windows render by forcing the `ne` condition to false and confirmed the template renders to an empty string, so chezmoi will skip the script.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [ ] Updated documentation if needed
- [x] Linter and tests pass locally
