### PR TITLE
fix(chezmoiscripts): guard update script against Windows OS

### DIFF
--- a/.chezmoiscripts/run_after_update.sh.tmpl
+++ b/.chezmoiscripts/run_after_update.sh.tmpl
@@ -1,4 +1,4 @@
-{{- ne .chezmoi.os "windows" -}}
+{{- if ne .chezmoi.os "windows" -}}
 #!/bin/sh
 if command -v bat > /dev/null 2>&1; then
     bat ~/.config/chezmoi/chezmoi.toml

--- a/.chezmoiscripts/run_after_update.sh.tmpl
+++ b/.chezmoiscripts/run_after_update.sh.tmpl
@@ -1,6 +1,8 @@
+{{- ne .chezmoi.os "windows" -}}
 #!/bin/sh
 if command -v bat > /dev/null 2>&1; then
     bat ~/.config/chezmoi/chezmoi.toml
 else
     cat ~/.config/chezmoi/chezmoi.toml
 fi
+{{- end -}}


### PR DESCRIPTION
[38;2;131;148;150m   1[0m [38;2;248;248;242m## Summary[0m
[38;2;131;148;150m   2[0m [38;2;248;248;242m- Wrap `run_after_update.sh.tmpl` with a Windows OS guard so the script is skipped on Windows[0m
[38;2;131;148;150m   3[0m [38;2;248;248;242m- Correct the template condition syntax[0m
[38;2;131;148;150m   4[0m 
[38;2;131;148;150m   5[0m [38;2;248;248;242m## Test plan[0m
[38;2;131;148;150m   6[0m [38;2;248;248;242m- [ ] Verify the update script runs on macOS/Linux[0m
[38;2;131;148;150m   7[0m [38;2;248;248;242m- [ ] Verify the update script is skipped on Windows[0m
[38;2;131;148;150m   8[0m 
[38;2;131;148;150m   9[0m [38;2;248;248;242m🤖 Generated with [Claude Code](https://claude.com/claude-code)[0m