### PR TITLE
Add profile template and gate tool fetches to home profile

### DIFF
--- a/.chezmoiscripts/run_before_update-claude-version.sh.tmpl
+++ b/.chezmoiscripts/run_before_update-claude-version.sh.tmpl
@@ -1,5 +1,5 @@
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
-{{- $profile := env "CHEZMOI_PROFILE" | default "home" -}}
+{{- $profile := includeTemplate "profile" . | trim -}}
 
 {{- $cachedClaudeVersion := index . "claudeVersion" | default "" -}}
 {{- $cachedClaudeHash := index . "claudeHash" | default "" -}}

--- a/.chezmoitemplates/claude-hash
+++ b/.chezmoitemplates/claude-hash
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "claudeVersion" | default "" -}}
 {{- $cachedHash := index . "claudeHash" | default "" -}}
@@ -10,4 +11,7 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/claude-url
+++ b/.chezmoitemplates/claude-url
@@ -1,4 +1,8 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "claude-version" . | trim -}}
 {{- printf "https://downloads.claude.ai/claude-code-releases/%s/%s-%s/claude" $version .chezmoi.os .chezmoi.arch -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/claude-version
+++ b/.chezmoitemplates/claude-version
@@ -1,3 +1,7 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "curl" "-fsSL" "https://downloads.claude.ai/claude-code-releases/latest" -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/copilot-hash
+++ b/.chezmoitemplates/copilot-hash
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "copilotVersion" | default "" -}}
 {{- $cachedHash := index . "copilotHash" | default "" -}}
@@ -10,4 +11,7 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/copilot-url
+++ b/.chezmoitemplates/copilot-url
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "copilot-version" . -}}
 {{- $os := .chezmoi.os -}}
@@ -6,4 +7,7 @@
   {{- $arch = "x64" -}}
 {{- end -}}
 {{- printf "https://github.com/github/copilot-cli/releases/download/%s/copilot-%s-%s.tar.gz" $version $os $arch -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/copilot-version
+++ b/.chezmoitemplates/copilot-version
@@ -1,3 +1,7 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" `curl -sI "https://github.com/github/copilot-cli/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/gemini-hash
+++ b/.chezmoitemplates/gemini-hash
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "geminiVersion" | default "" -}}
 {{- $cachedHash := index . "geminiHash" | default "" -}}
@@ -10,4 +11,7 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/gemini-url
+++ b/.chezmoitemplates/gemini-url
@@ -1,4 +1,8 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "gemini-version" . -}}
 {{- printf "https://registry.npmjs.org/@google/gemini-cli/-/gemini-cli-%s.tgz" $version -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/gemini-version
+++ b/.chezmoitemplates/gemini-version
@@ -1,3 +1,7 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" "curl -s https://registry.npmjs.org/@google/gemini-cli/latest | grep -o '\"version\":\"[^\"]*\"' | cut -d'\"' -f4" | trim -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/mise-hash
+++ b/.chezmoitemplates/mise-hash
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "miseVersion" | default "" -}}
 {{- $cachedHash := index . "miseHash" | default "" -}}
@@ -10,4 +11,7 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/mise-url
+++ b/.chezmoitemplates/mise-url
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "mise-version" . -}}
 {{- $os := .chezmoi.os -}}
@@ -9,5 +10,8 @@
   {{- $arch = "x64" -}}
 {{- end -}}
 {{- printf "https://github.com/jdx/mise/releases/download/%s/mise-%s-%s-%s.tar.gz" $version $version $os $arch -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}
 

--- a/.chezmoitemplates/mise-version
+++ b/.chezmoitemplates/mise-version
@@ -1,3 +1,7 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" `curl -sI "https://github.com/jdx/mise/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/profile
+++ b/.chezmoitemplates/profile
@@ -1,0 +1,6 @@
+{{- $profile := "home" -}}
+{{- if hasKey . "profile" }}
+{{- $profile = .profile }}
+{{- end -}}
+{{- $profile = env "CHEZMOI_PROFILE" | default $profile -}}
+{{- $profile -}}

--- a/.chezmoitemplates/yegappan-lsp-hash
+++ b/.chezmoitemplates/yegappan-lsp-hash
@@ -1,5 +1,9 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $url := "https://github.com/yegappan/lsp/archive/refs/heads/main.tar.gz" -}}
 {{- $hash := output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url --unpack '%s' 2>/dev/null)" $url) | trim -}}
 {{- $hash -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/zed-hash
+++ b/.chezmoitemplates/zed-hash
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "zedVersion" | default "" -}}
 {{- $cachedHash := index . "zedHash" | default "" -}}
@@ -10,4 +11,7 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/zed-url
+++ b/.chezmoitemplates/zed-url
@@ -1,3 +1,4 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "zed-version" . -}}
 {{- $os := .chezmoi.os -}}
@@ -12,4 +13,7 @@
 {{- else if eq $os "linux" -}}
     {{- printf "https://github.com/zed-industries/zed/releases/download/%s/zed-linux-%s.tar.gz" $version $arch -}}
 {{- end -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/zed-version
+++ b/.chezmoitemplates/zed-version
@@ -1,3 +1,7 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "sh" "-c" `curl -sI "https://github.com/zed-industries/zed/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
 {{- end -}}

--- a/private_dot_config/home-manager/exact_packages/vcs.nix
+++ b/private_dot_config/home-manager/exact_packages/vcs.nix
@@ -1,6 +1,7 @@
 { pkgs }:
 
 with pkgs; [
+  gh
   chezmoi
   delta
   git


### PR DESCRIPTION
## Summary
- Add `.chezmoitemplates/profile` to centralize profile resolution (default `home`, overridable via `profile` data key or `CHEZMOI_PROFILE` env)
- Gate the claude/copilot/gemini/mise/zed/yegappan-lsp version/url/hash templates and the claude pre-update script on `profile == "home"`, so non-home profiles skip the network fetches and hash computations
- Add `gh` to the home-manager vcs package list

## Test plan
- [ ] `chezmoi execute-template` against a representative template (e.g. `claude-version`) on the `home` profile returns the expected value
- [ ] Same template on a non-home profile (`CHEZMOI_PROFILE=work chezmoi execute-template ...`) returns an empty string and performs no network calls
- [ ] `chezmoi apply` succeeds end-to-end on macOS/Linux
- [ ] `home-manager switch` picks up `gh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)