### PR TITLE
fix(shell): correct hm() rebuild commands and quoting

### DIFF
--- a/dot_profile.d/home-manager.sh
+++ b/dot_profile.d/home-manager.sh
@@ -1,13 +1,13 @@
 function hm() {
+    local os current_dir
     os=$(uname)
-    current_dir=`pwd`
-    cd ${HOME}/.config/home-manager
+    current_dir=$(pwd)
+    cd "${HOME}/.config/home-manager" || return 1
     nix flake update
     if [[ "$os" == "Darwin" ]]; then
-        sudo darwin_rebuild switch --flake .#$(hostname -s)
-
+        sudo darwin-rebuild switch --flake ".#$(hostname -s)"
     else
-        home_manager_switch
+        home-manager switch --flake ".#$(whoami)"
     fi
-    cd $current_dir
+    cd "$current_dir"
 }


### PR DESCRIPTION
## Summary
- Fix the `hm()` helper in `dot_profile.d/home-manager.sh` so it calls real commands: `darwin-rebuild` and `home-manager switch --flake ".#$(whoami)"` (the old `darwin_rebuild` / `home_manager_switch` were command-not-found). The Linux flake target matches `homeConfigurations."${username}"` from `flake.nix.tmpl`.
- Declare `os` and `current_dir` as `local` so they no longer leak into the global shell environment.
- Replace backticks with `$(pwd)`, quote paths, and guard with `cd ... || return 1` so a failed `cd` won't run the rebuild in the wrong directory.

## Test plan
- [ ] `bash -n dot_profile.d/home-manager.sh` passes (verified locally)
- [ ] On macOS: `hm` runs `darwin-rebuild switch`
- [ ] On Linux: `hm` runs `home-manager switch --flake`

https://claude.ai/code/session_01N5RgbNdvPJ5dm77gWXT1um

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5RgbNdvPJ5dm77gWXT1um)_