### PR TITLE
feat(shell): emit WezTerm user var over SSH sessions

### DIFF
--- a/dot_profile.d/multiplexer.sh
+++ b/dot_profile.d/multiplexer.sh
@@ -1,5 +1,5 @@
 function set_wezterm_user_var(){
-    if [[ -n "$WEZTERM_PANE" ]]; then
+    if [[ -n "$WEZTERM_PANE" || -n "$SSH_CONNECTION" ]]; then
         printf "\033]1337;SetUserVar=%s=%s\007" "$1" $(echo -n "$2" | base64)
     fi
 }


### PR DESCRIPTION
## Summary
- Emit the WezTerm `SetUserVar` OSC sequence not only when `$WEZTERM_PANE` is set, but also when `$SSH_CONNECTION` is set.

## Why
`$WEZTERM_PANE` is a local environment variable that does not propagate over SSH, so on a remote host it is empty and the user var is never emitted — even though the local WezTerm (which reads the OSC sequence from the terminal stream) is fully capable of receiving it. Adding the `-n "$SSH_CONNECTION"` clause makes the sequence fire on remote sessions too. On a non-WezTerm terminal the sequence is simply ignored, so this is harmless.

## Test plan
- [ ] SSH into a remote host from WezTerm, run `tmux`/`zellij`, and confirm `TMUX_MODE` toggles in WezTerm.
- [ ] Confirm local (non-SSH) behavior is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_011RjvXK6LngRXZjFh1UhNLM)_