### PR TITLE
feat(nix): add ollama overlay and alacritty config

### DIFF
--- a/.chezmoiscripts/run_before_update-claude-version.sh.tmpl
+++ b/.chezmoiscripts/run_before_update-claude-version.sh.tmpl
@@ -19,6 +19,9 @@
 {{- $cachedAntigravityVersion := index . "antigravityVersion" | default "" -}}
 {{- $cachedAntigravityHash := index . "antigravityHash" | default "" -}}
 
+{{- $cachedOllamaVersion := index . "ollamaVersion" | default "" -}}
+{{- $cachedOllamaHash := index . "ollamaHash" | default "" -}}
+
 #!/bin/sh
 claude_version="{{- includeTemplate "claude-version" . -}}"
 if [ "$claude_version" = "{{- $cachedClaudeVersion -}}" ] \
@@ -74,6 +77,15 @@ else
     antigravity_hash="{{- includeTemplate "antigravity-hash" . -}}"
 fi
 
+ollama_version="{{- includeTemplate "ollama-version" . -}}"
+if [ "$ollama_version" = "{{- $cachedOllamaVersion -}}" ] \
+    && [ -n "{{- $cachedOllamaHash -}}" ]; then
+    echo "Ollama is up to date, using cached hash."
+    ollama_hash="{{- $cachedOllamaHash -}}"
+else
+    ollama_hash="{{- includeTemplate "ollama-hash" . -}}"
+fi
+
 if [ ! -d ~/.config/chezmoi ]; then
     mkdir -p ~/.config/chezmoi
 fi
@@ -97,6 +109,8 @@ miseVersion = "$mise_version"
 miseHash = "$mise_hash"
 antigravityVersion = "$antigravity_version"
 antigravityHash = "$antigravity_hash"
+ollamaVersion = "$ollama_version"
+ollamaHash = "$ollama_hash"
 EOF
 {{- end -}}
 

--- a/.chezmoitemplates/ollama-hash
+++ b/.chezmoitemplates/ollama-hash
@@ -1,0 +1,17 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
+{{- $cachedVersion := index . "ollamaVersion" | default "" -}}
+{{- $cachedHash := index . "ollamaHash" | default "" -}}
+{{- $latestVersion := includeTemplate "ollama-version" . | trim -}}
+{{- $hash := "" -}}
+{{- if and (eq $latestVersion $cachedVersion) (ne $cachedHash "") -}}
+  {{- $hash = $cachedHash -}}
+{{- else -}}
+  {{- $url := includeTemplate "ollama-url" . | trim -}}
+  {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
+{{- end -}}
+{{- $hash -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}

--- a/.chezmoitemplates/ollama-url
+++ b/.chezmoitemplates/ollama-url
@@ -1,0 +1,13 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
+{{- $version := includeTemplate "ollama-version" . | trim -}}
+{{- $base := "https://github.com/ollama/ollama/releases/download" -}}
+{{- if eq .chezmoi.os "darwin" -}}
+{{- printf "%s/%s/ollama-darwin.tgz" $base $version -}}
+{{- else -}}
+{{- printf "%s/%s/ollama-linux-%s.tar.zst" $base $version .chezmoi.arch -}}
+{{- end -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}

--- a/.chezmoitemplates/ollama-version
+++ b/.chezmoitemplates/ollama-version
@@ -1,0 +1,7 @@
+{{- if eq (includeTemplate "profile" . | trim) "home" -}}
+{{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
+{{- output "sh" "-c" `curl -sI "https://github.com/ollama/ollama/releases/latest/" | grep -oE 'tag/[^[:space:]]+' | cut -d/ -f2 | tr -d '[:space:]'` -}}
+{{- end -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}

--- a/private_dot_config/alacritty/alacritty.toml
+++ b/private_dot_config/alacritty/alacritty.toml
@@ -1,0 +1,16 @@
+[general]
+# git clone https://github.com/alacritty/alacritty-theme ~/.config/alacritty/themes
+import = [
+    "~/.config/alacritty/themes/themes/tokyo_night.toml"
+]
+
+[font]
+normal = { family = "Moralerspace Neon HW", style = "Regular" }
+size = 14.0
+
+[window]
+opacity = 0.9
+blur = false
+
+[terminal]
+osc52 = "CopyPaste"

--- a/private_dot_config/home-manager/exact_overlays/ollama.nix.tmpl
+++ b/private_dot_config/home-manager/exact_overlays/ollama.nix.tmpl
@@ -1,0 +1,27 @@
+final: prev:
+let
+  version = "{{ includeTemplate `ollama-version` . }}";
+in
+{
+  ollama =
+    if prev.stdenv.isDarwin then
+      prev.stdenv.mkDerivation {
+        pname = "ollama";
+        inherit version;
+        src = prev.fetchurl {
+          url = "{{ includeTemplate `ollama-url` . }}";
+          hash = "{{ includeTemplate `ollama-hash` . }}";
+        };
+        dontUnpack = true;
+        nativeBuildInputs = [ prev.makeWrapper ];
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out/lib/ollama $out/bin
+          tar -xzf $src -C $out/lib/ollama
+          makeWrapper $out/lib/ollama/ollama $out/bin/ollama
+          runHook postInstall
+        '';
+      }
+    else
+      prev.ollama;
+}

--- a/private_dot_config/home-manager/exact_packages/gui.nix
+++ b/private_dot_config/home-manager/exact_packages/gui.nix
@@ -1,13 +1,14 @@
 { pkgs }:
 
 with pkgs; [
-  vscode
-  zed-editor
+  alacritty
   drawio
-  obsidian
-  wezterm
-  moralerspace-hw
   julia-mono
-  noto-fonts-color-emoji
+  moralerspace-hw
   nerd-fonts.symbols-only
+  noto-fonts-color-emoji
+  obsidian
+  vscode
+  wezterm
+  zed-editor
 ]

--- a/private_dot_config/home-manager/exact_packages/gui.nix
+++ b/private_dot_config/home-manager/exact_packages/gui.nix
@@ -2,6 +2,7 @@
 
 with pkgs; [
   alacritty
+  alacritty-theme
   drawio
   julia-mono
   moralerspace-hw

--- a/private_dot_config/home-manager/exact_packages/gui.nix
+++ b/private_dot_config/home-manager/exact_packages/gui.nix
@@ -7,6 +7,7 @@ with pkgs; [
   obsidian
   wezterm
   moralerspace-hw
+  julia-mono
   noto-fonts-color-emoji
   nerd-fonts.symbols-only
 ]

--- a/private_dot_config/home-manager/flake.nix.tmpl
+++ b/private_dot_config/home-manager/flake.nix.tmpl
@@ -41,6 +41,7 @@
         (import ./overlays/zed-editor.nix)
         (import ./overlays/mise.nix)
         (import ./overlays/antigravity.nix)
+        (import ./overlays/ollama.nix)
       ];
     in
     if isDarwin then {


### PR DESCRIPTION
## Summary

Adds an Ollama overlay for home-manager with version caching, plus a few GUI/terminal config changes.

- Add `ollama-version`, `ollama-url`, and `ollama-hash` chezmoi templates that resolve the latest Ollama release and prefetch its hash.
- Add `overlays/ollama.nix.tmpl` that builds Ollama from the official Darwin release tarball (falls back to `prev.ollama` on Linux), and wire it into `flake.nix.tmpl`.
- Cache the resolved Ollama version/hash in `run_before_update-claude-version.sh.tmpl` to avoid re-prefetching on every apply.
- Add initial Alacritty configuration (`alacritty.toml`) with Tokyo Night theme, Moralerspace font, and OSC52 clipboard.
- Add `alacritty`, `alacritty-theme`, and `julia-mono` to GUI packages and sort the package list.

## Related Issues

<!-- N/A -->

## How Has This Been Tested?

- Ran `chezmoi diff` / `chezmoi apply` and verified only the intended files changed and templates render correctly.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [ ] Updated documentation if needed
- [x] Linter and tests pass locally
