### PR TITLE
fix(claude): fix Claude Code Nix install on Linux

### DIFF
--- a/.chezmoitemplates/claude-hash
+++ b/.chezmoitemplates/claude-hash
@@ -1,4 +1,3 @@
-{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $cachedVersion := index . "claudeVersion" | default "" -}}
 {{- $cachedHash := index . "claudeHash" | default "" -}}
@@ -11,7 +10,6 @@
   {{- $hash = output "sh" "-c" (printf "nix hash convert --to sri --hash-algo sha256 $(nix-prefetch-url '%s' 2>/dev/null)" $url) | trim -}}
 {{- end -}}
 {{- $hash -}}
-{{- end -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/claude-url
+++ b/.chezmoitemplates/claude-url
@@ -1,8 +1,10 @@
-{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- $version := includeTemplate "claude-version" . | trim -}}
-{{- printf "https://downloads.claude.ai/claude-code-releases/%s/%s-%s/claude" $version .chezmoi.os .chezmoi.arch -}}
+{{- $arch := .chezmoi.arch -}}
+{{- if eq $arch "amd64" -}}
+{{- $arch = "x64" -}}
 {{- end -}}
+{{- printf "https://downloads.claude.ai/claude-code-releases/%s/%s-%s/claude" $version .chezmoi.os $arch -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}

--- a/.chezmoitemplates/claude-version
+++ b/.chezmoitemplates/claude-version
@@ -1,7 +1,5 @@
-{{- if eq (includeTemplate "profile" . | trim) "home" -}}
 {{- if (or (eq .chezmoi.os "linux") (eq .chezmoi.os "darwin")) -}}
 {{- output "curl" "-fsSL" "https://downloads.claude.ai/claude-code-releases/latest" -}}
-{{- end -}}
 {{- else -}}
 {{- "" -}}
 {{- end -}}

--- a/private_dot_config/home-manager/exact_overlays/claude-code.nix.tmpl
+++ b/private_dot_config/home-manager/exact_overlays/claude-code.nix.tmpl
@@ -7,7 +7,11 @@ final: prev: {
       hash = "{{ includeTemplate `claude-hash` . }}";
     };
     dontUnpack = true;
-    nativeBuildInputs = [ prev.makeWrapper ];
+    nativeBuildInputs = [ prev.makeWrapper ]
+      ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
+    buildInputs = prev.lib.optionals prev.stdenv.isLinux [
+      prev.stdenv.cc.cc.lib
+    ];
     installPhase = ''
       install -Dm755 $src $out/bin/claude
     '';

--- a/private_dot_config/home-manager/exact_overlays/claude-code.nix.tmpl
+++ b/private_dot_config/home-manager/exact_overlays/claude-code.nix.tmpl
@@ -7,6 +7,11 @@ final: prev: {
       hash = "{{ includeTemplate `claude-hash` . }}";
     };
     dontUnpack = true;
+    # Claude Code is a Bun single-file executable: the Bun runtime with the
+    # app appended as a trailer (ends with a "Bun!" marker). Stripping rewrites
+    # the ELF and discards that trailer, which makes the binary fall back to
+    # behaving like plain `bun`, so it must be disabled on Linux.
+    dontStrip = true;
     nativeBuildInputs = [ prev.makeWrapper ]
       ++ prev.lib.optionals prev.stdenv.isLinux [ prev.autoPatchelfHook ];
     buildInputs = prev.lib.optionals prev.stdenv.isLinux [

--- a/private_dot_config/home-manager/home.nix.tmpl
+++ b/private_dot_config/home-manager/home.nix.tmpl
@@ -1,7 +1,7 @@
 { pkgs, ...}:
 
 let
-  profile = "{{ includeTemplate "profile" }}";
+  profile = "{{- includeTemplate `profile` . -}}";
 in
 {
   fonts.fontconfig.enable = true;


### PR DESCRIPTION
## Summary

Fixes Claude Code installation via the home-manager Nix overlay on Linux:

- Map the `amd64` arch to `x64` when building the download URL so the release
  asset resolves correctly.
- Run `autoPatchelfHook` (with `stdenv.cc.cc.lib`) on Linux so the downloaded
  binary's dynamic linker/dependencies are patched for NixOS.
- Disable stripping (`dontStrip = true`): Claude Code is a Bun single-file
  executable with the app appended as a trailer ending in a `Bun!` marker.
  Stripping rewrites the ELF and discards that trailer, making the binary fall
  back to plain `bun` behavior.
- Remove the `profile == "home"` guard from the `claude-url`, `claude-hash`,
  and `claude-version` chezmoi templates, and pass `.` / trim the rendered
  `profile` output in `home.nix.tmpl` so the template renders correctly.

## Related Issues

<!-- none -->

## How Has This Been Tested?

- Ran `chezmoi diff` / `chezmoi apply --dry-run` — only the intended files change.
- Verified template rendering of the `claude-url`, `claude-hash`, and
  `claude-version` templates.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [ ] Updated documentation if needed
- [ ] Linter and tests pass locally
