### PR TITLE
docs(detect-multiplexer): join description into one line

### DIFF
--- a/dot_claude/skills/detect-multiplexer/SKILL.md
+++ b/dot_claude/skills/detect-multiplexer/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: detect-multiplexer
-description: When you're asked to work on multiplexer pane,
-you MUST use this skill to detect the type of multiplexer.
+description: When you're asked to work on multiplexer pane, you MUST use this skill to detect the type of multiplexer.
 ---
 
 ## Detect multiplexer


### PR DESCRIPTION
## Summary

Join the `detect-multiplexer` skill's `description` frontmatter into a single line. A multi-line value in YAML frontmatter can be mis-parsed; collapsing it to one line keeps the description intact and unambiguous.

## Related Issues

<!-- none -->

## How Has This Been Tested?

- Reviewed the diff: only the `description` field of `dot_claude/skills/detect-multiplexer/SKILL.md` changed; wording is unchanged.
- No chezmoi templating involved (plain `.md` file), so no `chezmoi execute-template` rendering needed.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [ ] Updated documentation if needed
- [x] Linter and tests pass locally
