### PR TITLE
fix(opencode): correct disabled_providers typo

### DIFF
--- a/private_dot_config/opencode/base.jsonc
+++ b/private_dot_config/opencode/base.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "diabled_providers": [],
+  "disabled_providers": [],
   "autoupdate": false,
   "permission": {
     "external_directory": {


### PR DESCRIPTION
## Summary

Fix a typo in the opencode base config: the key `diabled_providers` was
misspelled and is now corrected to `disabled_providers` so the setting is
actually recognized by opencode.

## Related Issues

<!-- None -->

## How Has This Been Tested?

- Ran `chezmoi diff` — only the intended key in
  `private_dot_config/opencode/base.jsonc` changed.

## Checklist

- [x] Self-reviewed the diff
- [ ] Added/updated tests
- [ ] Updated documentation if needed
- [x] Linter and tests pass locally
