### PR TITLE
feat: tools for agent-to-agent session messaging

### DIFF
--- a/dot_bin/executable_agent_send
+++ b/dot_bin/executable_agent_send
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SLEEP_SECOND=0.1
+
+multiplexer=$(detect_multiplexer)
+
+pane_id=$1
+message=$2
+
+if [[ $multiplexer == "Zellij" ]]; then
+    zellij action write-chars --pane-id "${pane_id}" "${message}"
+    sleep ${SLEEP_SECOND}
+    zellij action write --pane-id "${pane_id}" 13
+elif [[ $multiplexer == "Tmux" ]]; then
+    tmux send-keys -t "${pane_id}" "$message"
+    sleep ${SLEEP_SECOND}
+    tmux send-keys -t "${pane_id}" Enter
+elif [[ $multiplexer == "WezTerm" ]]; then
+    wezterm cli send-text --pane-id "${pane_id}" "${message}"
+    sleep ${SLEEP_SECOND}
+    wezterm cli send-text --pane-id "${pane_id}" --no-paste $'\r'
+else
+  echo "Error: Unsupported multiplexer." >&2
+  exit 1
+fi

--- a/dot_bin/executable_agent_send.ps1
+++ b/dot_bin/executable_agent_send.ps1
@@ -1,0 +1,29 @@
+#!/usr/bin/env pwsh
+
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$PaneId,
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string]$Message
+)
+
+$SleepSecond = 0.1
+
+$multiplexer = detect_multiplexer.ps1
+
+if ($multiplexer -eq "Zellij") {
+    zellij action write-chars --pane-id $PaneId $Message
+    Start-Sleep -Seconds $SleepSecond
+    zellij action write --pane-id $PaneId 13
+} elseif ($multiplexer -eq "Tmux") {
+    tmux send-keys -t $PaneId $Message
+    Start-Sleep -Seconds $SleepSecond
+    tmux send-keys -t $PaneId Enter
+} elseif ($multiplexer -eq "WezTerm") {
+    wezterm cli send-text --pane-id $PaneId $Message
+    Start-Sleep -Seconds $SleepSecond
+    wezterm cli send-text --pane-id $PaneId --no-paste "`r"
+} else {
+    Write-Error "Error: Unsupported multiplexer."
+    exit 1
+}

--- a/dot_bin/executable_detect_multiplexer
+++ b/dot_bin/executable_detect_multiplexer
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ -n $ZELLIJ_PANE_ID ]]; then
+    echo "Zellij"
+elif [[ -n $TMUX_PANE ]]; then
+    echo "Tmux"
+elif [[ -n $WEZTERM_PANE ]]; then
+    echo "WezTerm"
+else
+    echo "None"
+fi

--- a/dot_bin/executable_detect_multiplexer.ps1
+++ b/dot_bin/executable_detect_multiplexer.ps1
@@ -1,0 +1,11 @@
+#!/usr/bin/env pwsh
+
+if ($env:ZELLIJ_PANE_ID) {
+    Write-Output "Zellij"
+} elseif ($env:TMUX_PANE) {
+    Write-Output "Tmux"
+} elseif ($env:WEZTERM_PANE) {
+    Write-Output "WezTerm"
+} else {
+    Write-Output "None"
+}

--- a/dot_bin/executable_register_agent
+++ b/dot_bin/executable_register_agent
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+session=$1
+role=$2
+name=$3
+
+is_init=false
+for arg in "$@"; do
+    if [[ $arg == "--init" || $arg == "-i" ]]; then
+        is_init=true
+        break
+    fi
+done
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+init_option=""
+if [[ $is_init == true ]]; then
+    init_option="--init"
+fi
+
+if command -v uv &> /dev/null; then
+    uv run "${script_dir}/register_agent.py" \
+        --session "$session" \
+        --role "$role" \
+        --name "$name" \
+        $init_option
+elif command -v python3 &> /dev/null; then
+    python3 "${script_dir}/register_agent.py" \
+        --session "$session" \
+        --role "$role" \
+        --name "$name" \
+        $init_option
+else
+    echo "Error: neither uv nor python3 is available." >&2
+    exit 1
+fi

--- a/dot_bin/executable_register_agent.ps1
+++ b/dot_bin/executable_register_agent.ps1
@@ -1,0 +1,38 @@
+#!/usr/bin/env pwsh
+
+param(
+    [Parameter(Position = 0, Mandatory = $true)]
+    [string]$Session,
+    [Parameter(Position = 1)]
+    [string]$Role,
+    [Parameter(Position = 2)]
+    [string]$Name,
+    [Alias("i")]
+    [switch]$Init
+)
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+$InitOption = @()
+if ($Init) {
+    $InitOption = @("--init")
+}
+
+if (Get-Command uv -ErrorAction SilentlyContinue) {
+    uv run "$ScriptDir/register_agent.py" `
+        --session $Session `
+        --role $Role `
+        --name $Name `
+        @InitOption
+}
+elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+    python3 "$ScriptDir/register_agent.py" `
+        --session $Session `
+        --role $Role `
+        --name $Name `
+        @InitOption
+}
+else {
+    Write-Error "Error: neither uv nor python3 is available."
+    exit 1
+}

--- a/dot_bin/executable_resolve_agent
+++ b/dot_bin/executable_resolve_agent
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+session=$1
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+if command -v uv &> /dev/null; then
+    uv run "${script_dir}/resolve_agent.py" --session "$session" 
+elif command -v python3 &> /dev/null; then
+    python3 "${script_dir}/register_agent.py" --session "$session" 
+else
+    echo "Error: neither uv nor python3 is available." >&2
+    exit 1
+fi

--- a/dot_bin/executable_resolve_agent.ps1
+++ b/dot_bin/executable_resolve_agent.ps1
@@ -1,0 +1,19 @@
+#!/usr/bin/env pwsh
+
+param(
+    [Parameter(Position = 0, Mandatory = $true)]
+    [string]$Session
+)
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+if (Get-Command uv -ErrorAction SilentlyContinue) {
+    uv run "$ScriptDir/resolve_agent.py" --session $Session
+}
+elseif (Get-Command python3 -ErrorAction SilentlyContinue) {
+    python3 "$ScriptDir/resolve_agent.py" --session $Session
+}
+else {
+    Write-Error "Error: neither uv nor python3 is available."
+    exit 1
+}

--- a/dot_bin/register_agent.py
+++ b/dot_bin/register_agent.py
@@ -1,0 +1,92 @@
+"""Register pane id for a session."""
+
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+from dataclasses import dataclass
+from dataclasses import asdict
+import json
+
+
+@dataclass
+class SessionPane:
+    pane_id: int
+    name: str
+    role: str
+
+
+parser = ArgumentParser(description="Register pane id for a session.")
+parser.add_argument(
+    "--session",
+    "-s",
+    type=str,
+    default="default",
+    help="Name of the session to register.",
+)
+parser.add_argument(
+    "--role",
+    "-r",
+    type=str,
+    default="agent",
+    help="Name of the role to register.",
+)
+parser.add_argument(
+    "--name",
+    "-n",
+    type=str,
+    default=None,
+    help="Name of the role to register.",
+)
+parser.add_argument(
+    "--init",
+    "-i",
+    action="store_true",
+    help="Whether to initialize the session.",
+)
+
+if (env_current_pane_id := os.environ.get("ZELLIJ_PANE_ID", None)) is not None:
+    current_pane_id = int(env_current_pane_id)
+    multiplexer = "Zellij"
+elif (env_current_pane_id := os.environ.get("TMUX_PANE", None)) is not None:
+    current_pane_id = int(env_current_pane_id)
+    multiplexer = "Tmux"
+elif (env_current_pane_id := os.environ.get("WEZTERM_PANE", None)) is not None:
+    current_pane_id = int(env_current_pane_id)
+    multiplexer = "WezTerm"
+
+args = parser.parse_args()
+
+session_filepath = Path.home() / ".tmp" / "agent-to-agent" / f"{args.session}.json"
+session_filepath.parent.mkdir(parents=True, exist_ok=True)
+if args.name is not None:
+    name = args.name
+else:
+    name = args.role
+if args.init or not session_filepath.exists():
+    dict_session = {
+        "multiplexer": multiplexer,
+        "panes": [
+            asdict(SessionPane(pane_id=current_pane_id, name=name, role=args.role))
+        ],
+    }
+else:
+    dict_session = json.loads(session_filepath.read_text())
+    panes = dict_session["panes"]
+    dict_role_counts = {}
+    duplicated_pane_id = None
+    for i_pane, pane in enumerate(panes):
+        if current_pane_id == pane["pane_id"]:
+            duplicated_pane_id = i_pane
+            break
+    if duplicated_pane_id is not None:
+        del panes[duplicated_pane_id]
+    for pane in panes:
+        dict_role_counts[pane["role"]] = dict_role_counts.get(pane["role"], 0) + 1
+        if name == pane["name"]:
+            name = f"{args.role}-{dict_role_counts[pane['role']] + 1}"
+            if pane["name"] == args.role:
+                pane["name"] = f"{args.role}-1"
+    panes.append(
+        asdict(SessionPane(pane_id=current_pane_id, name=name, role=args.role))
+    )
+json.dump(dict_session, session_filepath.open("w"))

--- a/dot_bin/register_agent.py
+++ b/dot_bin/register_agent.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from dataclasses import asdict
 import json
+from pprint import pprint
 
 
 @dataclass
@@ -90,3 +91,5 @@ else:
         asdict(SessionPane(pane_id=current_pane_id, name=name, role=args.role))
     )
 json.dump(dict_session, session_filepath.open("w"))
+print("You have registered the following pane to the session:")
+pprint(dict_session)

--- a/dot_bin/resolve_agent.py
+++ b/dot_bin/resolve_agent.py
@@ -1,0 +1,57 @@
+"""Resolve agent from a session file."""
+
+from typing import Literal
+
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+from dataclasses import dataclass
+import json
+from pprint import pprint
+
+
+@dataclass
+class SessionPane:
+    pane_id: int
+    name: str
+    role: str
+
+
+@dataclass
+class SessionData:
+    multiplexer: Literal["Zellij", "Tmux", "WezTerm"]
+    panes: list[SessionPane]
+
+
+parser = ArgumentParser(description="Register pane id for a session.")
+parser.add_argument(
+    "--session",
+    "-s",
+    type=str,
+    required=True,
+    help="Name of the session to register.",
+)
+
+if (env_current_pane_id := os.environ.get("ZELLIJ_PANE_ID", None)) is not None:
+    current_pane_id = int(env_current_pane_id)
+    multiplexer = "Zellij"
+elif (env_current_pane_id := os.environ.get("TMUX_PANE", None)) is not None:
+    current_pane_id = int(env_current_pane_id)
+    multiplexer = "Tmux"
+elif (env_current_pane_id := os.environ.get("WEZTERM_PANE", None)) is not None:
+    current_pane_id = int(env_current_pane_id)
+    multiplexer = "WezTerm"
+
+args = parser.parse_args()
+
+session_filepath = Path.home() / ".tmp" / "agent-to-agent" / f"{args.session}.json"
+dict_session: SessionData = json.loads(session_filepath.read_text())
+panes = dict_session["panes"]
+for pane in panes:
+    if pane["pane_id"] == current_pane_id:
+        name = pane["name"]
+other_panes = [pane for pane in panes if pane["pane_id"] != current_pane_id]
+print(f"Your pane_id: {current_pane_id}")
+print(f"Your name: {name}")
+print("Other pane information is following:")
+pprint(other_panes)

--- a/dot_claude/skills/agent-to-agent/SKILL.md
+++ b/dot_claude/skills/agent-to-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-to-agent
-description: When you're asked to communicate to other agents, you MUST use this skill.
+description: When you're asked to communicate to other agents (a2a session), you MUST use this skill.
 ---
 
 # Agent to Agent
@@ -9,24 +9,41 @@ This skill is used when you're asked to communicate to other agents.
 You MUST use this skill when you need to send messages to other agents,
 and you MUST follow the format specified in the skill description.
 
-- Setup agent to agent communication
-- Send message to other agents
+## Initialize Agent to Agent Session
 
-## Setup agent to agent communication
-
-Before working on any other tasks in this skill, you MUST run this task once.
+IF you're asked to initialize an `agent-to-agent` (`a2a`) session,
+THEN you MUST run `register_agent <session_name> <role> <name> --init` to
+create a session file.
 
 ### Procedure
 
-1. Use [[detect-multiplexer]] skill to detect your session.
-2. Load the skill for the detected multiplexer.
-3. Detect your pane ID and store it in the context for later use.
-4. Detect other pane IDs in the same session and
-   store them in the context for later use.
-5. Respond to the user that the setup is complete
-   and you are ready to communicate with other agents.
-   You MUST include your pane ID
-   and the list of other pane IDs in the response.
+1. Analyze user's request and understand the session details,
+   such as session name, your role, and your name.
+2. Run `register_agent <session_name> <role> <name> --init` to
+   create a session file.
+
+### Rules
+
+- If `session_name` is not specified, use "default" as the session name.
+- If `name` is not specified, use your role as the name.
+
+## Register to Agent to Agent Session
+
+IF you're asked to register to an `agent-to-agent` (`a2a`) session,
+THEN you MUST run `register_agent <session_name> <role> <name>` to
+register to the session.
+
+### Procedure
+
+1. Analyze user's request and understand the session details,
+   such as session name, your role, and your name.
+2. Run `register_agent <session_name> <role> <name> --init` to
+   create a session file.
+
+### Rules
+
+- If `session_name` is not specified, use "default" as the session name.
+- If `name` is not specified, use your role as the name.
 
 ## Send message to other agent
 
@@ -39,14 +56,16 @@ keep to send a message to the agents when you receive a request.
 
 1. Analyze the requested message.
 2. Create a response message.
-3. Send the message to another agent using command:
+3. Send the message to another agent using following command:
 
    ```
    agent_send <pane_id> "<message>"
    ```
 
-   - `<pane_id>` is the pane ID of the other agent you want to send the message to.
-   - `<message>` is the message you want to send to the other agent.
+### Rules
+
+- `<pane_id>` is the pane ID of the other agent you want to send the message to.
+- `<message>` is the message you want to send to the other agent.
 
 ## Test communication
 

--- a/dot_claude/skills/agent-to-agent/SKILL.md
+++ b/dot_claude/skills/agent-to-agent/SKILL.md
@@ -45,6 +45,17 @@ register to the session.
 - If `session_name` is not specified, use "default" as the session name.
 - If `name` is not specified, use your role as the name.
 
+## Resolve Agent to Agent Session
+
+If you're asked to resolve an `agent-to-agent` (`a2a`) session,
+THEN you MUST run `resolve_agent <session_name>` to
+reolve the your pane id, name and other agents' information from the session file.
+
+### Procedure
+
+1. Run `resolve_agent <session_name>` to resolve the session information.
+2. Get your pane id, name and other agents' information from the session file.
+
 ## Send message to other agent
 
 When you're asked to communicate to other agents, you MUST send a message

--- a/dot_claude/skills/agent-to-agent/SKILL.md
+++ b/dot_claude/skills/agent-to-agent/SKILL.md
@@ -39,7 +39,14 @@ keep to send a message to the agents when you receive a request.
 
 1. Analyze the requested message.
 2. Create a response message.
-3. Send the message to another agent using the skill.
+3. Send the message to another agent using command:
+
+   ```
+   agent_send <pane_id> "<message>"
+   ```
+
+   - `<pane_id>` is the pane ID of the other agent you want to send the message to.
+   - `<message>` is the message you want to send to the other agent.
 
 ## Test communication
 

--- a/dot_claude/skills/detect-multiplexer/SKILL.md
+++ b/dot_claude/skills/detect-multiplexer/SKILL.md
@@ -8,55 +8,9 @@ description: When you're asked to work on multiplexer pane, you MUST use this sk
 Before working on a multiplexer pane, you MUST use this skill to detect the type of multiplexer.
 
 Detect the type of multiplexer by checking the environment variables.
-The type must be either `Tmux`, `Zellij` or `Wezterm`.
-
-If you run on Windows PowerShell, to check a environment variable with the following command:
-
-```ps1
-echo $env:ENV_VARIABLE
-```
-
-If you run on Linux or macOS (bash or zsh), to check a environment variable with the following command:
-
-```sh
-echo $ENV_VARIABLE
-```
-
-> [!NOTE]
-> Replace `ENV_VARIABLE` with the actual environment variable name that indicates the multiplexer type.
-> For example, `TMUX_PANE` for Tmux, `ZELLIJ_PANE_ID` for Zellij, and `WEZTERM_PANE` for Wezterm.
+The type must be either `Tmux`, `Zellij` or `WezTerm`.
 
 ### Procedure
 
-1. Check the environment variables `ZELLIJ_PANE_ID`.
-   If the variable is defined, the session type is `Zellij`
-
-2. Check the environment variables `TMUX_PANE_ID`.
-   If the variable is defined, the session type is `Tmux`
-
-3. Check the environment variables `WEZTERM_PANE`.
-   If the variable is defined, the session type is `Wezterm`
-
-> [!NOTE]
-> The priority of the checks is as follows: `Zellij` > `Tmux` > `Wezterm`.
-> If multiple environment variables are defined, the first one that is detected will determine the multiplexer type.
-
-> [!CAUTION]
-> You MUST verify each variable one by one in the order of priority.
-> Do NOT check all variables at once, as it may lead to incorrect detection if multiple variables are defined.
->
-> This is a strict requirement to ensure accurate detection of the multiplexer type.
->
-> ✅ Correct:
->
-> ```sh
-> echo $ZELLIJ_PANE_ID
-> echo $TMUX_PANE
-> echo $WEZTERM_PANE
-> ```
->
-> ❌ Incorrect:
->
-> ```sh
-> echo $ZELLIJ_PANE_ID; echo $TMUX_PANE; echo $WEZTERM_PANE;
-> ```
+1. Run command `detect_multiplexer`, and the output will be
+   the type of multiplexer, which must be either `Tmux`, `Zellij` or `WezTerm`.

--- a/private_dot_config/opencode/base.jsonc
+++ b/private_dot_config/opencode/base.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "default_agent": "developer",
   "disabled_providers": [],
   "autoupdate": false,
   "permission": {
@@ -64,7 +65,10 @@
       "tail *.env*": "deny",
       "tail *.key*": "deny",
       "tail *.pem*": "deny",
-      "tail *secret*": "deny"
+      "tail *secret*": "deny",
+      "agent_sent *": "allow",
+      "register_agent *": "allow",
+      "resolve_agent *": "allow"
     },
     "edit": {
       "*": "ask",
@@ -95,5 +99,25 @@
     "webfetch": "ask",
     "websearch": "allow",
     "question": "allow"
+  },
+  "provider": {
+    "ollama": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Ollama (local)",
+      "options": {
+        "baseURL": "http://localhost:11434/v1"
+      },
+      "models": {
+        "gemma4:e2b-mlx": {
+          "name": "gemma4:e2b-mlx"
+        },
+        "gemma4:e4b-mlx": {
+          "name": "gemma4:e4b-mlx"
+        },
+        "gemma4:12b-mlx": {
+          "name": "gemma4:12b-mlx"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds tooling to support agent-to-agent communication across terminal multiplexers (Zellij, Tmux, WezTerm).

## Changes

- **Multiplexer detection** — bash and PowerShell scripts to detect Zellij, Tmux, or WezTerm; docs updated to use `detect_multiplexer` instead of manual env-var checks.
- **agent_send** — cross-multiplexer scripts to send messages to agent panes.
- **register_agent** — registers pane id, name, and role per session into a pane registry, with a shell wrapper and session pane info printing.
- **resolve_agent** — retrieves session pane info; the agent-to-agent skill documents the full resolve flow.
- **opencode config** — new permissions and ollama provider.

## Test plan

- [ ] Verify `detect_multiplexer` correctly identifies the active multiplexer
- [ ] Verify `register_agent` / `resolve_agent` round-trip pane info
- [ ] Verify `agent_send` delivers messages to the target pane

https://claude.ai/code/session_01SxQvzGbtf8d6tYgNdF5cuj

---
_Generated by [Claude Code](https://claude.ai/code/session_01SxQvzGbtf8d6tYgNdF5cuj)_